### PR TITLE
bugfix: modify the regex to allow dash

### DIFF
--- a/R/blsAPI.R
+++ b/R/blsAPI.R
@@ -70,7 +70,7 @@ blsAPI <- function(payload=NA, api_version=1, return_data_frame=FALSE){
     if (is.list(payload)){
       # Multiple Series or One or More Series, Specifying Years request
       payload <- toJSON(payload)
-      m <- regexpr('\\"seriesid\\":\\"[a-zA-Z0-9]*\\",', payload)
+      m <- regexpr('\\"seriesid\\":\\"[a-zA-Z0-9-]*\\",', payload)
       str <- regmatches(payload, m)
       if (length(str) > 0){
         # wrap single series in []


### PR DESCRIPTION
previous regex assumed alphanumeric series IDs and does not anticipate those with '-' character such as 'PCU11331-11331-'. Added dash character to regex as fix.

addresses [this open issue](https://github.com/mikeasilva/blsAPI/issues/33#issue-1124545249)